### PR TITLE
Add note about NODE_ENV in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ SSRCaching.setCachingConfig(cacheConfig);
 
 Where `cacheConfig` contains information on what component to apply caching.  See below for details.
 
+In order for the `enableCaching()` method to work, you'll also need `NODE_ENV` set to `production`, or else it will throw an error.
+
 ### cacheConfig
 
 SSR component caching was first demonstrated in [Sasha Aickin's talk].


### PR DESCRIPTION
If you don't set `NODE_ENV` to `production` React will throw a `TypeError` because you are trying to modify props of a component when running with `enableCache(true)`

I spent a good hour trying to figure out what was wrong, so i guess it would be helpful if this was at least mentioned in the README
