### PR TITLE
Add missing chai devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-react": "^6.11.1",
     "babel-register": "^6.9.0",
+    "chai": "^3.5.0",
     "electrode-archetype-njs-module-dev": "^1.0.1",
     "gulp": "^3.9.1",
     "mock-require": "^1.3.0",


### PR DESCRIPTION
`npm t` errors on new clone due to missing Chai dependency.
