### PR TITLE
Change cacheHitReport() method to return Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Get total number of cache entries
 
 ### [`cacheHitReport()`](#cachehitreport)
 
-Print out cache entries and number of hits each one has.
+Returns an object with information about cache entry hits
 
 Built with :heart: by [Team Electrode](https://github.com/orgs/electrode-io/people) @WalmartLabs.
 

--- a/lib/ssr-caching.js
+++ b/lib/ssr-caching.js
@@ -361,10 +361,14 @@ exports.cacheEntries = function () {
 };
 
 exports.cacheHitReport = function () {
+  const hitReport = {};
   Object.keys(cacheStore.cache).forEach((key) => {
     const entry = cacheStore.cache[key];
-    console.log(`Cache Entry ${key} Hits ${entry.hits}`); // eslint-disable-line
+    hitReport[key] = {
+      hits: entry.hits
+    };
   });
+  return hitReport;
 };
 
 exports.config = config;

--- a/test/spec/caching.template.spec.js
+++ b/test/spec/caching.template.spec.js
@@ -101,7 +101,12 @@ describe("SSRCaching template caching", function () {
     expect(entry.hits).to.equal(2);
     expect(r2).includes(message);
     verifyRenderResults(r1, r2, r3);
-    SSRCaching.cacheHitReport();
+
+    const hitReport = SSRCaching.cacheHitReport();
+    Object.keys(hitReport).forEach((key) => {
+      console.log(`Cache Entry ${key} Hits ${hitReport[key].hits}`); // eslint-disable-line
+    });
+
     expect(SSRCaching.cacheEntries()).to.equal(2);
     expect(SSRCaching.cacheSize()).to.be.above(0);
   });


### PR DESCRIPTION
Calling cacheHitReport would `console.log` out message which was
impractical for production use.

Changed the method to return an object instead which would
be much more flexible and easier to reason with in production

I preserved the original console.log and moved it to the test instead,
so the tests are passing and producing the exact same output as before

Also has the flexibility to add more info about each cache key entry in the future, like cache size/length or similar. 
