### PR TITLE
Fix electrode-boilerplate issue #43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+
+node_js:
+  - v6
+
+brances:
+  only:
+    - master
+
+before_install:
+  - currentfolder=${PWD##*/}
+  - if [ "$currentfolder" != 'electrode-react-ssr-caching' ]; then cd .. && eval "mv $currentfolder electrode-react-ssr-caching" && cd electrode-react-ssr-caching; fi
+
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ brances:
     - master
 
 before_install:
+  - npm install farmhash
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'electrode-react-ssr-caching' ]; then cd .. && eval "mv $currentfolder electrode-react-ssr-caching" && cd electrode-react-ssr-caching; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ brances:
     - master
 
 before_install:
-  - npm install farmhash
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'electrode-react-ssr-caching' ]; then cd .. && eval "mv $currentfolder electrode-react-ssr-caching" && cd electrode-react-ssr-caching; fi
 
 script:
-  - npm test
+  - gulp check

--- a/lib/ssr-caching.js
+++ b/lib/ssr-caching.js
@@ -2,8 +2,8 @@
 
 /* eslint-disable no-magic-numbers */
 
-const ReactCompositeComponent = require("react/lib/ReactCompositeComponent");
-const DOMPropertyOperations = require("react/lib/DOMPropertyOperations");
+const ReactCompositeComponent = require("react-dom/lib/ReactCompositeComponent");
+const DOMPropertyOperations = require("react-dom/lib/DOMPropertyOperations");
 const assert = require("assert");
 const _ = require("lodash");
 const CacheStore = require("./cache-store");
@@ -145,10 +145,10 @@ const replacements = {
   '"': "&quot;"  // eslint-disable-line
 };
 
-ReactCompositeComponent.Mixin._construct = ReactCompositeComponent.Mixin.construct;
-ReactCompositeComponent.Mixin._mountComponent = ReactCompositeComponent.Mixin.mountComponent;
+ReactCompositeComponent._construct = ReactCompositeComponent.construct;
+ReactCompositeComponent._mountComponent = ReactCompositeComponent.mountComponent;
 
-ReactCompositeComponent.Mixin.construct = function (element) {
+ReactCompositeComponent.construct = function (element) {
   if (config.enabled) {
     if (config.profiling) {
       this.__p = {time: undefined};
@@ -160,10 +160,10 @@ ReactCompositeComponent.Mixin.construct = function (element) {
   return this._construct(element);
 };
 
-ReactCompositeComponent.Mixin.__profileTime = function () {
+ReactCompositeComponent.__profileTime = function () {
 };
 
-ReactCompositeComponent.Mixin.__realProfileTime = function (start) {
+ReactCompositeComponent.__realProfileTime = function (start) {
   const name = this._name;
   const d = process.hrtime(start);
   const owner = this._currentElement._owner;
@@ -223,7 +223,7 @@ const templatePostProcess = (r, lookup, realProps, transaction, hostContainerInf
   return transaction.renderToStaticMarkup ? r : updateReactId(r, hostContainerInfo);
 };
 
-ReactCompositeComponent.Mixin.mountComponentCache = function mountComponentCache(transaction, hostParent, hostContainerInfo, context, parentDebugID) { // eslint-disable-line
+ReactCompositeComponent.mountComponentCache = function mountComponentCache(transaction, hostParent, hostContainerInfo, context, parentDebugID) { // eslint-disable-line
 
   let template;
   let cached;
@@ -388,4 +388,3 @@ exports.setCachingConfig = function (cfg) {
 exports.blackListed = blackListed;
 
 exports.clearCache();
-


### PR DESCRIPTION
### Fixes https://github.com/electrode-io/electrode-boilerplate-universal-react-node/issues/43

![screen shot 2016-11-16 at 10 11 40 am](https://cloud.githubusercontent.com/assets/360041/20359521/1bace4ac-abe5-11e6-8143-30fe6c10d7fc.png)

This callstack error happened as part of the react v15.4.0 release https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html

> there is a possibility that you imported private APIs from react/lib/*, or that a package you rely on might use them.
 
* moving `react/lib/*` dependencies to `react-dom/lib/*` to fix this issue.

* moving away from using Mixin as part of migrating to react v15.4.0

`reference commit of react removing the Mixin layer of indirection` https://github.com/facebook/react/commit/dd0c65c6aa7c80eeeb0783e29bef89399b5796af

Boilerplate server start with this pr change:
![screen shot 2016-11-16 at 10 17 02 am](https://cloud.githubusercontent.com/assets/360041/20359725/ed266c2e-abe5-11e6-8117-b77b602a7511.png)

/cc @jchip 