### PR TITLE
[WIP] Initial attempt at async cache store

### DIFF
--- a/lib/cache-store.js
+++ b/lib/cache-store.js
@@ -41,13 +41,17 @@ CacheStore.prototype.newEntry = function (name, key, value) {
 };
 
 CacheStore.prototype.getEntry = function (name, key) {
-  const entryKey = `${name}-${key}`;
-  const x = this.cache[entryKey];
-  if (x) {
-    x.hits++;
-    x.access = Date.now();
-  }
-  return x;
+  return new Promise((res, rej) => {
+    const entryKey = `${name}-${key}`;
+    const x = this.cache[entryKey];
+    if (x) {
+      x.hits++;
+      x.access = Date.now();
+      res(x);
+      return;
+    }
+    rej();
+  });
 };
 
 module.exports = CacheStore;

--- a/lib/ssr-caching.js
+++ b/lib/ssr-caching.js
@@ -223,10 +223,13 @@ const templatePostProcess = (r, lookup, realProps, transaction, hostContainerInf
   return transaction.renderToStaticMarkup ? r : updateReactId(r, hostContainerInfo);
 };
 
+// must be cleared after rendering
+let cachePromises = [];
+
 ReactCompositeComponent.mountComponentCache = function mountComponentCache(transaction, hostParent, hostContainerInfo, context, parentDebugID) { // eslint-disable-line
 
   let template;
-  let cached;
+  let cachePromise;
   let key;
   let cacheType;
   let opts;
@@ -251,19 +254,63 @@ ReactCompositeComponent.mountComponentCache = function mountComponentCache(trans
         cacheKey: opts.genCacheKey ? opts.genCacheKey(saveProps) : JSON.stringify(saveProps)
       };
       key = hashKeyFn(template.cacheKey);
-      cached = cacheStore.getEntry(name, key);
-      if (cached) {
-        this.__profileTime(startTime);
-        let r = cached.html;
-        if (!transaction.renderToStaticMarkup) {
-          r = updateReactId(cached.html, hostContainerInfo);
-        }
-        if (!hostParent) {
-          r = addRootMarkup(r);
-        }
-        return config.debug ?
-          `<!-- component ${name} cacheType HIT ${key} -->${r}` : r;
-      }
+
+      const tempMarkup = `<!-- electrode:${name}:${key} -->`;
+
+      const saveId = hostContainerInfo._idCounter;
+
+      cachePromise = cacheStore.getEntry(name, key) // will return a promise.
+        .catch(() => { // didnt find in cache, render for real
+          hostContainerInfo._idCounter = 1;
+          transaction._cached = this._name;
+
+          // overriding for comps which make updates to state on compwillmount. since we
+          // render comps after the transaction has ended (after we know if we have them
+          // in cache or not), they dont hold a ref anymore to the last rendered
+          // component (which seems to be necessary on updates). this simplifies setState
+          // on the server which seems to be common (well react-apollo does it). let's
+          // hope it doesn't overlook other issues
+          const _originalSetState = Component.prototype.setState;
+          Component.prototype.setState = function (partialState) {
+            this.state = Object.assign({}, this.state, partialState);
+          };
+
+          const html = this._mountComponent(transaction, hostParent, hostContainerInfo, context, parentDebugID);
+
+          Component.prototype.setState = _originalSetState;
+
+          const cacheObj = { html: html.replace(` ${MARKUP_FOR_ROOT}`, "") };
+
+          hostContainerInfo._idCounter = saveId;
+          currentElement.props = saveProps;
+          cacheStore.newEntry(name, key, cacheObj);
+
+          transaction._cached = undefined;
+
+          return cacheObj;
+        })
+        .then((cached) => {
+          let r = cached.html;
+
+          if (!transaction.renderToStaticMarkup) {
+            r = updateReactId(cached.html, hostContainerInfo);
+          }
+
+          if (!hostParent) {
+            r = addRootMarkup(r);
+          }
+
+          if (config.debug) {
+            r = `<!-- component ${name} cacheType HIT ${key} -->${r}`;
+          }
+
+          return { tempMarkup, html: r };
+        });
+
+      cachePromises.push(cachePromise);
+
+      return tempMarkup;
+
     } else if (strategy === "template") {
       cacheType = "cache";
       template = generateTemplate(saveProps, opts);
@@ -320,6 +367,30 @@ ReactCompositeComponent.mountComponentCache = function mountComponentCache(trans
   } else {
     return r;
   }
+};
+
+exports.replaceWithCachedValues = function (markup) {
+  return Promise.all(cachePromises).then((cachedValues) => {
+
+    const cacheMap = {};
+    let regex = '';
+
+    cachedValues.forEach(({ tempMarkup, html }, idx) => {
+      idx !== 0 && (regex += '|');
+      regex += tempMarkup;
+      cacheMap[tempMarkup] = html;
+    });
+
+    markup = markup.replace(new RegExp(`(${regex})`, 'g'), (m) => cacheMap[m]);
+
+    cachePromises = [];
+
+    return markup;
+  }).catch((e) => {
+    cachePromises = [];
+
+    return Promise.reject(e);
+  });
 };
 
 exports.enableProfiling = function (flag) {


### PR DESCRIPTION
To be used like this:

```
let html = renderToString(reactTree);
html = replaceWithCachedValues(html);
```

1. `cacheStore.getEntry` will now return a promise. This will be useful with other
cache stores (memcached?)

2. `mountComponentCache` ("simple" strategy only for now) will now always return a
placeholder markup (consists of name + key)

3. if nothing found in cache, cache promise is rejected and the "real"
component is mounted, stored in cache, and then resolved as if it was in
cache all along

4. when all cache promises resolve (either found in cache or mounted and stored), we do a quick
str.replace on the global markup

#### TODO:
- still probably need to update the global markup checksum...
- this hacks setState which im not 100% sure is safe (tho only on server
and when the cache promise is rejected [ie not found in cache])
- if we dont call replaceWithCachedValues after rendering we got
ourselves a mem leak..
- im sure i broke other things too 🤷‍♀️  