### PR TITLE
fix for react-empty having wrong ids

### DIFF
--- a/lib/ssr-caching.js
+++ b/lib/ssr-caching.js
@@ -209,7 +209,7 @@ const addRootMarkup = (r) => {
   return r.replace(/(<[^ >]*)([ >])/, (m, a, b) => `${a} ${MARKUP_FOR_ROOT}${b}`);
 };
 
-const REACT_ID_REPLACE_REGEX = new RegExp(`(data-reactid="|react-text: )[0-9]*`, "g");
+const REACT_ID_REPLACE_REGEX = new RegExp(`(data-reactid="|react-text: |react-empty: )[0-9]*`, "g");
 
 const updateReactId = (r, hostContainerInfo) => { // eslint-disable-line
   let id = hostContainerInfo._idCounter;


### PR DESCRIPTION
In this commit ( https://github.com/facebook/react/commit/358140679cbda686f8c3a7d04887342188572cb0#diff-97aa1b59c62bd0df37d1b497d515945bR42 ) `react-empty` was added to replace `null` values.
Currently code doesn't take this into account, so I was getting error:

> React attempted to reuse markup in a container but the checksum was invalid. This generally means that you are using server rendering and the markup generated on the server was not what the client was expecting. React injected new markup to compensate which works but you have lost many of the benefits of server rendering. Instead, figure out why the markup being generated is different on the client or server:
 (client) "><!-- react-empty: 110 --><section clas
 (server) "><!-- react-empty: 2 --><section class=

This pull request fixes it.