### PR TITLE
Update cache-store.js

### DIFF
--- a/lib/cache-store.js
+++ b/lib/cache-store.js
@@ -28,10 +28,11 @@ CacheStore.prototype.cleanCache = function (minFreeSize) {
 CacheStore.prototype.newEntry = function (name, key, value) {
   const entryKey = `${name}-${key}`;
   const size = entryKey.length + value.html.length;
-  const newSize = this.size + size;
+  var newSize = this.size + size;
   if (newSize > this.config.MAX_CACHE_SIZE) {
     const freeSize = Math.max(size, this.config.minFreeCacheSize);
     this.cleanCache(Math.min(freeSize, this.config.maxFreeCacheSize));
+    newSize = this.size + size;
   }
   this.cache[entryKey] = value;
   value.hits = 0;


### PR DESCRIPTION
Reset newSize variable after call to cleanCache since cleanCache modifies this.size.  Without this change the stored this.size doesn't accurately represent the cache size.  So when the cache becomes full and the process to clear out old items starts this.size never decrements, resulting in an empty cache and no ability to write new entires.